### PR TITLE
Fix random/trig.html checkbox label: "for" attribute refers to id, not name of checkbox

### DIFF
--- a/random/trig.html
+++ b/random/trig.html
@@ -28,7 +28,7 @@
         <div id="area">
             <canvas id="theCanvas" width="1280" height="720"></canvas>
             <div id="blurb">
-                <input type="checkbox" name="units" onclick="degrees = this.checked;">
+                <input type="checkbox" id="units" onclick="degrees = this.checked;">
                 <label for="units">Degrees (default is radians)</label>
             </div>
         </div>


### PR DESCRIPTION
This way, you can click the label instead of the checkbox itself. (tested on Firefox)